### PR TITLE
Add local settings to fix conflicts

### DIFF
--- a/plugin/aerojump.vim
+++ b/plugin/aerojump.vim
@@ -12,3 +12,11 @@ nnoremap <silent> <Plug>(AerojumpFromCursorBolt) :Aerojump cursor bolt <cword> <
 nnoremap <silent> <Plug>(AerojumpShowLog) :AerojumpShowLog<Return>
 nnoremap <silent> <Plug>(AerojumpResumeNext) :AerojumpResumeNext<Return>
 nnoremap <silent> <Plug>(AerojumpResumePrev) :AerojumpResumePrev<Return>
+
+" Changes settings that conflict with aerojump
+augroup AerojumpBufSettings
+  au!
+  au Filetype AerojumpFilter setlocal nosplitbelow nosplitright
+  au Filetype *.aerojump setlocal nolist
+augroup END
+


### PR DESCRIPTION
Closes #8 

Also sets nolist as it is often used to show trailing whitespace which looks bad since non-matching lines are replaced by spaces.

I was considering adding this to the python init but thought it'd be better in the plugin file as it is easier to add to for others since other settings might be found down the road.